### PR TITLE
add ipa and xcarchive files to gitignore

### DIFF
--- a/brd-ios/.gitignore
+++ b/brd-ios/.gitignore
@@ -8,6 +8,8 @@
 ## Build generated
 build/
 DerivedData/
+*.xcarchive
+*.ipa
 
 ## Various settings
 *.pbxuser


### PR DESCRIPTION
This adds two file extensions to gitignore to prevent build artifacts from being checked in